### PR TITLE
Fix issue #140: frontend login redirects via env vars

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,3 @@
-// frontend/src/App.jsx
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import Home from "./pages/Home";
@@ -9,10 +8,6 @@ import SignIn from "./pages/register/Login";
 import ContactPage from "./pages/ContactPage";
 import AboutPage from "./pages/AboutPage";
 
-// 👇 Import the dashboard entry points
-import StudentRoom from "../../dashboard/src/components/Student/StudentDashboardPages/Studentroom.jsx";
-import TeacherRoom from "../../dashboard/src/components/Teacher/TeacherDashboardPages/Teacherroom.jsx";
-
 const routes = [
   { path: "/", element: <Home /> },
   { path: "/signup", element: <Signup /> },
@@ -21,10 +16,6 @@ const routes = [
   { path: "/signin", element: <SignIn /> },
   { path: "/contact", element: <ContactPage /> },
   { path: "/about", element: <AboutPage /> },
-
-  // 👇 new ones
-  { path: "/student/*", element: <StudentRoom /> },
-  { path: "/teacher/*", element: <TeacherRoom /> },
 ];
 
 function App() {

--- a/frontend/src/pages/register/Login.jsx
+++ b/frontend/src/pages/register/Login.jsx
@@ -23,16 +23,15 @@ const Login = () => {
       localStorage.setItem("userId", data.user?.id);
       localStorage.setItem("userType", data.user?.userType);
 
-      //  Get URLs from .env
-      const studentUrl = import.meta.env.VITE_STUDENT_DASHBOARD_URL;
-      const teacherUrl = import.meta.env.VITE_TEACHER_DASHBOARD_URL;
+     const studentUrl = import.meta.env.VITE_STUDENT_DASHBOARD_URL;
+const teacherUrl = import.meta.env.VITE_TEACHER_DASHBOARD_URL;
 
-      //  Redirect by role (with query params, and /dashboard so overview shows)
-  if (data.user?.userType === "Student") {
-  window.location.href = `${import.meta.env.VITE_STUDENT_DASHBOARD_URL}/dashboard?token=${data.token}&userId=${data.user.id}`;
+if (data.user?.userType === "Student") {
+  window.location.href = `${studentUrl}/dashboard?token=${data.token}&userId=${data.user.id}`;
 } else if (data.user?.userType === "Teacher") {
-  window.location.href = `${import.meta.env.VITE_TEACHER_DASHBOARD_URL}/dashboard?token=${data.token}&userId=${data.user.id}`;
+  window.location.href = `${teacherUrl}/dashboard?token=${data.token}&userId=${data.user.id}`;
 }
+
 
 
     } catch (err) {


### PR DESCRIPTION

This PR fixes Issue #140, which caused build errors when deploying due to direct imports between the frontend and dashboard folders.

Changes Made

Removed direct imports of dashboard components into frontend/src/App.jsx.

Implemented a redirect-based approach for login:

On successful login, users are redirected to the appropriate dashboard using environment variables.

Token and userId are passed in query parameters and stored in localStorage for persistence.

Updated dashboard pages (Dashboard.jsx) to correctly read token and userId from query params or fallback to localStorage.

Verified that overview pages now load correctly without showing blank screens.

Testing

Local environment: Login flow works, user is redirected to the correct dashboard, token and userId are stored, and overview page loads.

Netlify deployment (branch issue-140-auth): Build now completes successfully. Login currently fails only because the backend needs to enable CORS for the Netlify domain.

Next Steps

Backend team should whitelist https://digicurriculum-app.netlify.app in CORS configuration. Once this is done, login will work on the deployed site.